### PR TITLE
Fixed the drift in time, when collecting the target data from the par…

### DIFF
--- a/matlab_packages/rbmcda/kf_nmcda_collect2.m
+++ b/matlab_packages/rbmcda/kf_nmcda_collect2.m
@@ -1,0 +1,173 @@
+%KF_NMCDA_COLLECT  Collects and smooth trajectories from NMCDA output
+%
+% Syntax:
+%   [FM,FP,SM,SP,Times] = kf_nmcda_collect(SS,A,Q [,silent])
+%
+% In:
+%   SS     - NTxNP cell array of NP particle structures in NT time steps
+%   A      - Transition matrix of discrete model (optional, default identity)
+%   Q      - Process noise of discrete model     (optional, default zero)
+%   silent - Should the function be silent
+% 
+% Out:
+%   FM    - Filtered means of each target in each particle
+%   FP    - Filtered covariances of each target in each particle
+%   SM    - Smoothed means of each target in each particle
+%   SP    - Smoothed covariances of each target in each particle
+%   Times - Time instances when each target was alive in each particle
+%
+% Description:
+%   Collects and smooths target trajectories from NMCDA outputs.
+%
+% See also:
+%   NMCDA_INIT, KF_NMCDA_PREDICT, KF_NMCDA_UPDATE, 
+%
+% History:
+%   11.02.2008 JH Added description and cleared the code a bit. 
+%   30.10.2003 SS The first official version.
+%
+% Copyright (C) 2003 Simo S�rkk�
+%               2008 Jouni Hartikainen
+%
+% $Id: kf_nmcda_collect.m, $
+%
+% This software is distributed under the GNU General Public
+% Licence (version 2 or later); please refer to the file
+% Licence.txt, included with the software, for details.
+function [FM,FP,SM,SP,Times,Births,Deaths] = kf_nmcda_collect2(SS,A,Q,T,silent)
+
+if nargin < 2
+    A = [];
+end
+if nargin < 3
+    Q = [];
+end
+if nargin < 5
+    silent = [];
+end
+if isempty(silent)
+    silent = 0;
+end
+
+FM    = {}; % Filtered means
+FP    = {}; % Filtered covariances
+SM    = {}; % Smoothed means
+SP    = {}; % Smoothed covariances
+Times = {}; % Times
+Births = [];
+Deaths = [];
+
+NP = size(SS,2); % Number of particles
+for ind=1:NP
+    if ~silent
+        fprintf('Processing particle %d/%d\n',ind,NP);
+    end
+
+    % Helper variables
+    NN=[];
+    MM={};
+    PP={};
+    TT={};
+    count=0;
+    n=0;
+    t=0; 
+    for k=1:size(SS,1)
+        t = T(k); 
+        if ~isempty(SS{k,ind})
+
+            %
+            % Death of a target
+            %
+            if (SS{k,ind}.D ~= 0)
+
+                count = count + 1;
+                %
+                % Store filtered result
+                %
+                j = SS{k,ind}.D;
+                Times{count,ind} = TT{j};
+                FM{count,ind} = MM{j};
+                FP{count,ind} = PP{j};
+
+                %
+                % Store smoothed result
+                %
+                [mm,pp] = rts_smooth(MM{j},PP{j},A,Q);
+                SM{count,ind} = mm;
+                SP{count,ind} = pp;
+
+                %
+                % Remove the target
+                %
+                if j == 1
+                    TT = TT(2:end);
+                    MM = MM(2:end);
+                    PP = PP(2:end);
+                elseif j == length(MM)
+                    TT = TT(1:end-1);
+                    MM = MM(1:end-1);
+                    PP = PP(1:end-1);
+                else
+                    TT = TT([1:j-1 j+1:end]);
+                    MM = MM([1:j-1 j+1:end]);
+                    PP = PP([1:j-1 j+1:end]);
+                end
+
+                TT{n} = [];
+                MM{n} = [];
+                PP{n} = [];
+                n = n - 1;
+            end
+
+            %
+            % Birth
+            %
+            if (SS{k,ind}.B > 0)
+                n = n + 1;
+                MM{n} = [];
+                PP{n} = [];
+                TT{n} = []; 
+            end
+
+            %
+            % Store the data for each alive target
+            %
+            if n > 0
+                for j=1:n
+                    MM{j} = [MM{j} SS{k,ind}.M{j}];
+                    PP{j}(:,:,size(MM{j},2)) = SS{k,ind}.P{j};
+                    TT{j} = [TT{j} t];
+                end 
+            end
+            
+            NN = [NN n];  
+        end
+    end
+
+    %
+    % Store the alive ones at the last time step
+    %
+    if n > 0
+        for j=1:n
+            count = count + 1;
+
+            %
+            % Store filtered result
+            %
+            Times{count,ind} = TT{j};
+            FM{count,ind} = MM{j};
+            FP{count,ind} = PP{j};
+
+            %
+            % Store smoothed result
+            %
+            [mm,pp] = rts_smooth(MM{j},PP{j},A,Q);
+            SM{count,ind} = mm;
+            SP{count,ind} = pp;
+        end
+    end
+     
+end
+if ~silent
+    fprintf('Done.\n');
+end

--- a/multisignal_tracking_2d.m
+++ b/multisignal_tracking_2d.m
@@ -28,7 +28,7 @@ clc
 
 %% I/O
 
-example = 2; % options - [1, 2]
+example = 1; % options - [1, 2]
 if example ==1
     % % % Example 1 - Stationary source
     % NOTE: ideally the stationary source location in the input data will be in
@@ -165,7 +165,8 @@ for k=1:size(Y,2)
         fprintf('Resampling done on time step %d\n',k);
     end
 end
-[FM,FP,SM,SP,Times] = kf_nmcda_collect(SS,A,Q);
+%[FM,FP,SM,SP,Times] = kf_nmcda_collect(SS,A,Q);
+[FM,FP,SM,SP,Times] = kf_nmcda_collect2(SS,A,Q,T);
 
 %% VISUALIZATON
 


### PR DESCRIPTION
…ticle objects

This resolves the drifting in time problem of the example, thus producing the plots more in-line with those in the README. 
The reason the temporal drift occurs, is that the RBMCDA framework is not expecting multiple observations at the same time. In the example data, there are instances where 2 DoA estimates are given at one time index, and the original kf_nmcda_collect.m wrongly assumes that time has advanced by 2 steps, but in reality it has only moved by 1 step. Hence, the added kf_nmcda_collect2.m function takes time "T" as an input argument, so the data collection is aware of this, so no drifting in time can occur. 